### PR TITLE
Add support for Nix (x86_64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,39 @@ ln -sf "$(pwd)/target/release/keyzen" ~/.local/bin/keyzen
 # Add ~/.local/bin to your PATH if not already there
 ```
 
+### Nix
+
+Try out Keyzen with:
+
+```bash
+nix run github:akshitvigg/keyzen
+```
+
+Or, install the package by adding this repo's flake to your inputs:
+
+```nix
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+
+    keyzen = {
+      url = "github:akshitvigg/keyzen";
+    };
+  };
+```
+
+and including its default package in your `home.packages` in the case of
+Home Manager, or your `environment.systemPackages` in the case of NixOS. For
+example, with NixOS, it might look like:
+
+```nix
+{ pkgs, inputs, ... }:
+{
+  environment.systemPackages = [
+    inputs.keyzen.packages.${pkgs.system}.default
+  ];
+}
+```
+
 ## Usage
 
 ### Basic Commands

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1755615617,
+        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,42 @@
+{
+  description = "A terminal-based typing test game written in Rust.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachSystem [ "x86_64-linux" ] (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+      in
+      {
+        packages.default = pkgs.rustPlatform.buildRustPackage {
+          pname = cargoToml.package.name;
+          inherit (cargoToml.package) version;
+          src = ./.;
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+          };
+
+          meta = {
+            inherit (cargoToml.package) description;
+            inherit (cargoToml.package) license;
+          };
+
+          nativeBuildInputs = with pkgs; [ pkg-config ];
+
+          buildInputs = with pkgs; [ alsa-lib ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
Hey, I found your project through Twitter, and it's pretty cool!

This PR adds a Nix flake that packages Keyzen for x86_64 Linux.

## Maintenance

Overall, the maintenance cost of Nix support is very low. The flake reads information like the project name, version, license, and dependencies directly from the `Cargo.toml` and `Cargo.lock`. Changing any of these values won't require modifications to the flake.

That said, the `flake.lock` file needs updating occasionally, however, this can be automated with something like Dependabot.

True manual upkeep is only required when external dependencies are added to Keyzen (i.e., those not listed in the `Cargo.toml`). For example, Keyzen depends on `alsa-lib`, which I've had to explicitly include on line 38 of `flake.nix`.

---

I'm more than happy to maintain this flake going forward if Nix support is something you're interested in adding.

Also, if you'd like, I can submit another PR that adds an action to ensure the Nix build stays functional.
